### PR TITLE
deps: updates wazero to 1.0.0-pre.4

### DIFF
--- a/cmd/wasabi/main.go
+++ b/cmd/wasabi/main.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 
 	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	"github.com/tetratelabs/wazero/sys"
-	"github.com/tetratelabs/wazero/wasi_snapshot_preview1"
 )
 
 func main() {
@@ -25,11 +25,9 @@ func main() {
 	goOs := strings.ToLower(runtime.GOOS)
 	//If AoT is supported activate it else run in interpreted mode
 	if ((goArch == "amd64") || (goArch == "arm64")) && ((goOs == "windows") || (goOs == "linux")) {
-		r = wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfigCompiler().
-			WithWasmCore2().WithFeatureBulkMemoryOperations(true))
+		r = wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigCompiler())
 	} else {
-		r = wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfigInterpreter().
-			WithWasmCore2().WithFeatureBulkMemoryOperations(true))
+		r = wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigInterpreter())
 	}
 
 	defer r.Close(ctx) // This closes everything this Runtime created.
@@ -64,7 +62,7 @@ func main() {
 	}
 
 	// Compile the WebAssembly module using the default configuration.
-	code, err := r.CompileModule(ctx, catWasm, wazero.NewCompileConfig())
+	code, err := r.CompileModule(ctx, catWasm)
 	if err != nil {
 		log.Panicln(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/bleakview/wasabi
 
 go 1.18
 
-require github.com/tetratelabs/wazero v0.0.0-20220812081006-d7d18a5519e6 // indirect
+require github.com/tetratelabs/wazero v1.0.0-pre.4

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v0.0.0-20220812081006-d7d18a5519e6 h1:TEaSLWw5JT+Nk6WBIu2fl6uNWhOIu9U6zow+ugbD+bc=
-github.com/tetratelabs/wazero v0.0.0-20220812081006-d7d18a5519e6/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
+github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
+github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.4](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.4).

Notably, v1.0.0-pre.4:
* improves module initialization speed
* supports listeners in the compiler engine
* supports WASI `fd_pread`, `fd_readdir` and `path_filestat_get`